### PR TITLE
feat: 유적지 추천 기능 구현 (#25)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	// spring security crypto
 	implementation 'org.springframework.security:spring-security-crypto'
+
+	// json
+	implementation("org.json:json:20240303")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/capstone/HisTour/domain/api/controller/APIController.java
+++ b/src/main/java/com/capstone/HisTour/domain/api/controller/APIController.java
@@ -1,6 +1,6 @@
-package com.capstone.HisTour.domain.tts.controller;
+package com.capstone.HisTour.domain.api.controller;
 
-import com.capstone.HisTour.domain.tts.service.TTSService;
+import com.capstone.HisTour.domain.api.service.TTSService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class TTSController {
+public class APIController {
 
     private final TTSService ttsService;
 

--- a/src/main/java/com/capstone/HisTour/domain/api/service/ChatGPTService.java
+++ b/src/main/java/com/capstone/HisTour/domain/api/service/ChatGPTService.java
@@ -1,0 +1,128 @@
+package com.capstone.HisTour.domain.api.service;
+
+import com.capstone.HisTour.domain.heritage.domain.Heritage;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ChatGPTService {
+
+    @Value("${api.openai.api-key}")
+    String openAIKey;
+
+    private final RestClient restClient;
+
+    public Map<Long, String> recommendFromContext(List<Heritage> visited,
+                                               List<Heritage> bookmarked,
+                                               List<Heritage> candidates) {
+
+        // 프롬프트 생성
+        String prompt = buildPrompt(visited, bookmarked, candidates);
+
+        // OpenAI API 호출 및 Map<id:추천이유> 반환
+       return callOpenAI(prompt);
+    }
+
+    private String buildPrompt(List<Heritage> visited, List<Heritage> bookmarked, List<Heritage> candidates) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("당신은 한국 문화유산 추천 전문가입니다.\n");
+
+        if (visited.isEmpty()) {
+            sb.append("사용자는 아직 방문한 유적지가 없습니다.\n");
+        } else {
+            sb.append("사용자는 이전에 다음과 같은 유적지를 방문했습니다:\n");
+            for (Heritage heritage : visited) {
+                sb.append("- ").append(heritage.toString()).append("\n");
+            }
+        }
+
+        if (bookmarked.isEmpty()) {
+            sb.append("\n사용자는 북마크한 유적지가 없습니다.\n");
+        } else {
+            sb.append("\n사용자는 다음 유적지를 북마크했습니다:\n");
+            for (Heritage heritage : bookmarked) {
+                sb.append("- ").append(heritage.toString()).append("\n");
+            }
+        }
+
+        sb.append("\n아래는 추천 후보로 고려할 수 있는 유적지 목록입니다:\n");
+        for (Heritage heritage : candidates) {
+            sb.append("- ").append(heritage.toString()).append("\n");
+        }
+
+        sb.append("""
+        이제 후보 유적지 중에서 최대 5개를 추천해주세요.
+        방문했던 유적지와 **역사적·시대적·지리적으로 관련 있는 유적지를 우선적으로 추천**하고, 북마크한 유적지도 고려해주세요.
+        사용자가 아무 유적지도 방문하지 않았거나 북마크하지 않았다면, **후보 유적지 중 역사적으로 가치 있는 유적지**를 무작위로 골라 그 이유를 설명해주세요.
+        
+        반드시 다음 형식으로 JSON 배열 형식으로만 응답해주세요:
+        [
+          {
+            "id": 1234,
+            "reason": "이 유적지는 경복궁과 같은 조선 시대 궁궐로, 사용자가 이전에 방문한 유적지와 역사적 배경이 유사합니다."
+          },
+          ...
+        ]
+        
+        반드시 한국어로 작성해주세요. 너무 형식적이지 않은, 자연스러운 설명을 부탁드립니다.
+        """);
+
+        return sb.toString();
+    }
+
+    private Map<Long, String> callOpenAI(String prompt) {
+        String apiUrl = "https://api.openai.com/v1/chat/completions";
+
+        Map<String, Object> body = Map.of(
+                "model", "gpt-4",
+                "messages", List.of(Map.of("role", "user", "content", prompt)),
+                "temperature", 0.7
+        );
+
+        JsonNode response = restClient.post()
+                .uri(apiUrl)
+                .header("Authorization", "Bearer " + openAIKey)
+                .header("Content-Type", "application/json")
+                .body(body)
+                .retrieve()
+                .body(JsonNode.class);
+
+
+        String content = response
+                .path("choices").get(0)
+                .path("message").path("content").asText();
+
+        System.out.println(content);
+
+        Map<Long, String> recommendations = new LinkedHashMap<>();
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode arrayNode = mapper.readTree(content);
+
+            if (arrayNode.isArray()) {
+                for (JsonNode obj : arrayNode) {
+                    long id = obj.path("id").asLong();
+                    String reason = obj.path("reason").asText();
+                    if (id != 0 && reason != null && !reason.isBlank()) {
+                        recommendations.put(id, reason);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to parse OpenAI response: " + e.getMessage());
+        }
+
+        return recommendations;
+    }
+}

--- a/src/main/java/com/capstone/HisTour/domain/api/service/OpenWeatherService.java
+++ b/src/main/java/com/capstone/HisTour/domain/api/service/OpenWeatherService.java
@@ -1,0 +1,75 @@
+package com.capstone.HisTour.domain.api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class OpenWeatherService {
+
+    @Value("${api.open-weather.api-key}")
+    String openWeatherKey;
+
+    private final RestClient restClient;
+
+    // indoor only 반환 함수
+    public boolean isIndoorOnly(Double lat, Double lon) {
+
+        // openweather api 호출 결과 json
+        JSONObject response = new JSONObject(getWeatherJson(lat, lon));
+
+        // 가장 가까운 시간대 예보 사용
+        JSONObject weatherData = response.getJSONArray("list").getJSONObject(0);
+
+        JSONObject main = weatherData.getJSONObject("main");
+        double tempCelsius = main.getDouble("temp");
+
+        // clouds, rain, snow 등, 날씨 조회
+        String weatherMain = weatherData
+                .getJSONArray("weather")
+                .getJSONObject(0)
+                .getString("main")
+                .toLowerCase();
+
+        // 강수확률 조회
+        double pop = weatherData.has("pop") ? weatherData.getDouble("pop") : 0.0;
+
+        // 강수량 조회
+        double rain = 0.0;
+        if (weatherData.has("rain")) {
+            rain = weatherData.getJSONObject("rain").optDouble("3h", 0.0);
+        }
+
+        // 눈내리는양 조회
+        double snow = 0.0;
+        if (weatherData.has("snow")) {
+            snow = weatherData.getJSONObject("snow").optDouble("3h", 0.0);
+        }
+
+        // IndoorOnly 인지 true, false 반환
+        return weatherMain.contains("rain")
+                || weatherMain.contains("snow")
+                || pop > 0.3
+                || rain > 1.0
+                || snow > 0.0
+                || tempCelsius < 0.0
+                || tempCelsius > 30.0;
+    }
+
+    // openweather api 호출
+    private String getWeatherJson(Double lat, Double lon) {
+        String url = "http://api.openweathermap.org/data/2.5/forecast?"
+                + "lat=" + lat
+                + "&lon=" + lon
+                + "&units=metric"
+                + "&appid=" + openWeatherKey;
+
+        return restClient.get()
+                .uri(url)
+                .retrieve()
+                .body(String.class);
+    }
+}

--- a/src/main/java/com/capstone/HisTour/domain/api/service/TTSService.java
+++ b/src/main/java/com/capstone/HisTour/domain/api/service/TTSService.java
@@ -1,7 +1,6 @@
-package com.capstone.HisTour.domain.tts.service;
+package com.capstone.HisTour.domain.api.service;
 
 import com.google.cloud.texttospeech.v1.*;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -10,7 +9,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class TTSService {
 

--- a/src/main/java/com/capstone/HisTour/domain/heritage/controller/HeritageController.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/controller/HeritageController.java
@@ -1,6 +1,7 @@
 package com.capstone.HisTour.domain.heritage.controller;
 
 import com.capstone.HisTour.domain.heritage.dto.HeritageListResponse;
+import com.capstone.HisTour.domain.heritage.dto.HeritageRecommendListResponse;
 import com.capstone.HisTour.domain.heritage.dto.HeritageResponse;
 import com.capstone.HisTour.domain.heritage.service.HeritageService;
 import com.capstone.HisTour.global.DefaultResponse;
@@ -68,7 +69,7 @@ public class HeritageController {
     }
 
     // 근처 유적지 조회 후
-    // (가장 가까운 유적지 이름) + (나머지 유적지 개수) 의 문자열 반환
+    // '(가장 가까운 유적지 이름) + (나머지 유적지 개수)' 알람 메시지 반환
     @GetMapping("/nearby-for-alarm")
     @MeasureExecutionTime
     public ResponseEntity<DefaultResponse<HeritageListResponse>> getHeritageNearbyForAlarm(
@@ -127,6 +128,27 @@ public class HeritageController {
         DefaultResponse<HeritageListResponse> response = DefaultResponse.response(
                 "경로상에 있는 유적지 조회 성공",
                 heritagesInRoute
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    // 유적지 추천
+    @GetMapping("/recommend")
+    public ResponseEntity<DefaultResponse<HeritageRecommendListResponse>> recommendHeritages(
+            @RequestHeader(value = "Authorization") String token,
+            @RequestParam Double latitude,
+            @RequestParam Double longitude
+    ) {
+        Long memberId = getMemberIdFromToken(token);
+
+        HeritageRecommendListResponse recommendedHeritages =  heritageService.recommendHeritages(memberId, latitude, longitude);
+
+        DefaultResponse<HeritageRecommendListResponse> response = DefaultResponse.response(
+                "유적지 추천 성공",
+                recommendedHeritages
         );
 
         return ResponseEntity

--- a/src/main/java/com/capstone/HisTour/domain/heritage/domain/Heritage.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/domain/Heritage.java
@@ -46,8 +46,17 @@ public class Heritage {
     @Column(name = "ccbactcd")
     private String locationCode;
 
+    @Column(name = "era")
+    private String era;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "side")
+    private String side;
+
     @Builder
-    public Heritage(String name, String category, String detailAddress, String description, Region region, Point geom, String categoryCode, String manageNum, String locationCode) {
+    public Heritage(String name, String category, String detailAddress, String description, Region region, Point geom, String categoryCode, String manageNum, String locationCode,  String era, String type,  String side) {
         this.name = name;
         this.category = category;
         this.detailAddress = detailAddress;
@@ -57,5 +66,15 @@ public class Heritage {
         this.categoryCode = categoryCode;
         this.manageNum = manageNum;
         this.locationCode = locationCode;
+        this.era = era;
+        this.type = type;
+        this.side = side;
+    }
+
+    @Override
+    public String toString() {
+        return "id: " + this.getId() + ", name: " + this.getName()
+                + ", category: " + this.getCategory()
+                + ", era: " + this.getEra() + ", type: " + this.getType() + ", side: " + this.getSide();
     }
 }

--- a/src/main/java/com/capstone/HisTour/domain/heritage/domain/HeritageRecommend.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/domain/HeritageRecommend.java
@@ -1,0 +1,37 @@
+package com.capstone.HisTour.domain.heritage.domain;
+
+import com.capstone.HisTour.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "heritage_recommend")
+@NoArgsConstructor
+@Getter
+public class HeritageRecommend {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "heritage_id", nullable = false)
+    private Heritage heritage;
+
+    @Column(name = "reason", nullable = false, columnDefinition = "TEXT")
+    private String reason;
+
+    @Builder
+    public HeritageRecommend(Member member, Heritage heritage, String reason) {
+        this.member = member;
+        this.heritage = heritage;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/capstone/HisTour/domain/heritage/dto/HeritageRecommendListResponse.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/dto/HeritageRecommendListResponse.java
@@ -1,0 +1,13 @@
+package com.capstone.HisTour.domain.heritage.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class HeritageRecommendListResponse {
+    private int count;
+    private List<HeritageRecommendResponse> recommendations;
+}

--- a/src/main/java/com/capstone/HisTour/domain/heritage/dto/HeritageRecommendResponse.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/dto/HeritageRecommendResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class HeritageResponse {
+public class HeritageRecommendResponse {
     private Long id;
     private String name;
     private String category;
@@ -22,10 +22,10 @@ public class HeritageResponse {
     private String era;
     private String side;
     private String type;
+    private String recommendReason;
 
-    // Heritage -> HeritageResponse 변환
-    public static HeritageResponse from(Heritage heritage, List<String> imageUrls) {
-        return HeritageResponse.builder()
+    public static HeritageRecommendResponse from(Heritage heritage, List<String> imageUrls, String recommendReason) {
+        return HeritageRecommendResponse.builder()
                 .id(heritage.getId())
                 .name(heritage.getName())
                 .category(heritage.getCategory())
@@ -38,6 +38,7 @@ public class HeritageResponse {
                 .era(heritage.getEra())
                 .side(heritage.getSide())
                 .type(heritage.getType())
+                .recommendReason(recommendReason)
                 .build();
     }
 }

--- a/src/main/java/com/capstone/HisTour/domain/heritage/repository/HeritageRecommendRepository.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/repository/HeritageRecommendRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.HisTour.domain.heritage.repository;
+
+import com.capstone.HisTour.domain.heritage.domain.HeritageRecommend;
+import com.capstone.HisTour.domain.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HeritageRecommendRepository extends JpaRepository<HeritageRecommend, Long> {
+    List<HeritageRecommend> findAllByMember(Member member);
+}


### PR DESCRIPTION
- 방문했던 유적지, 북마크했던 유적지, 근처 유적지, 날씨 등을 고려해서 필터링 후, ChatGPT API를 사용하여 추천하는 알고리즘 구현
- Heritage entity에 era(시대), type(종류), side(실내외) 컬럼 추가
- 외부 API api package에서 한 번에 관리