### PR TITLE
fix: 근처 유적지 조회 API 성능 개선

### DIFF
--- a/src/main/java/com/capstone/HisTour/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/capstone/HisTour/domain/alarm/service/AlarmService.java
@@ -41,7 +41,7 @@ public class AlarmService {
                 .orElse(null);
 
         // find nearby heritages using lat, long, range
-        HeritageListResponse heritagesNearby = heritageService.getHeritageNearby(memberId,
+        HeritageListResponse heritagesNearby = heritageService.getHeritageNearby(
                 alarmRequest.getLatitude(), alarmRequest.getLongitude(), alarmRequest.getRange());
 
         Map<String, Object> message = new HashMap<>();

--- a/src/main/java/com/capstone/HisTour/domain/heritage/controller/HeritageController.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/controller/HeritageController.java
@@ -44,7 +44,9 @@ public class HeritageController {
                 .body(response);
     }
 
+    // 근처 유적지 조회
     @GetMapping("/nearby")
+    @MeasureExecutionTime
     public ResponseEntity<DefaultResponse<HeritageListResponse>> getHeritageNearby(
             @RequestHeader(value = "Authorization") String token,
             @RequestParam Double latitude,
@@ -55,7 +57,7 @@ public class HeritageController {
         Long memberId = getMemberIdFromToken(token);
 
         // 근처 유적지 조회
-        HeritageListResponse heritageResponses = heritageService.getHeritageNearby(memberId, latitude, longitude, radius);
+        HeritageListResponse heritageResponses = heritageService.getHeritageNearby(latitude, longitude, radius);
 
         // ResponseDto 생성
         DefaultResponse<HeritageListResponse> response = DefaultResponse.response(

--- a/src/main/java/com/capstone/HisTour/domain/heritage/domain/Heritage.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/domain/Heritage.java
@@ -5,10 +5,11 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.locationtech.jts.geom.Point;
 
 @Entity
-@Table(name = "heritage")
+@Table(name = "heritage", indexes = @Index(name = "idx_heritage_geom", columnList = "geom"))
 @NoArgsConstructor
 @Getter
 public class Heritage {

--- a/src/main/java/com/capstone/HisTour/domain/heritage/repository/HeritageRepository.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/repository/HeritageRepository.java
@@ -9,19 +9,32 @@ import java.util.List;
 
 public interface HeritageRepository extends JpaRepository<Heritage, Long> {
 
+//    @Query(value = """
+//    SELECT *,
+//           ST_Distance(
+//                geom::geography,\s
+//                ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography
+//           ) AS distance
+//    FROM heritage
+//    WHERE ST_DWithin(
+//        geom::geography,
+//        ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
+//        :radius
+//    )
+//    ORDER BY distance ASC
+//    """, nativeQuery = true)
+//    List<Heritage> findNearbyHeritages(@Param("latitude") double latitude,
+//                                       @Param("longitude") double longitude,
+//                                       @Param("radius") double radius);
+
     @Query(value = """
-    SELECT *,
-           ST_Distance(
-                geom::geography,\s
-                ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography
-           ) AS distance
+    SELECT *
     FROM heritage
     WHERE ST_DWithin(
-        geom::geography, 
-        ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
-        :radius
+        geom,
+        ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326),
+        :radius/111320
     )
-    ORDER BY distance ASC
     """, nativeQuery = true)
     List<Heritage> findNearbyHeritages(@Param("latitude") double latitude,
                                        @Param("longitude") double longitude,

--- a/src/main/java/com/capstone/HisTour/domain/heritage/service/ImageApiService.java
+++ b/src/main/java/com/capstone/HisTour/domain/heritage/service/ImageApiService.java
@@ -1,6 +1,7 @@
 package com.capstone.HisTour.domain.heritage.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -18,13 +19,14 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ImageApiService {
 
     private final RestClient restClient;
 
     @Cacheable(value = "heritageImageUrls", key = "#ccbaKdcd + '_' + #ccbaAsno + '_' + #ccbaCtcd")
     public List<String> getCachedImageUrls(String ccbaKdcd, String ccbaAsno, String ccbaCtcd) {
-        System.out.println("DEBUG: Calling external image API for " + ccbaKdcd + "/" + ccbaAsno + "/" + ccbaCtcd);
+        log.debug("DEBUG: Calling external image API for {} / {}  / {} ", ccbaKdcd, ccbaAsno, ccbaCtcd);
         String url = "https://www.khs.go.kr/cha/SearchImageOpenapi.do" +
                 "?ccbaKdcd=" + ccbaKdcd +
                 "&ccbaAsno=" + ccbaAsno +


### PR DESCRIPTION
- geometry 컬럼에 대해 index 생성 후 적용
- 조회된 모든 유적지의 이미지 url을 우선 캐싱하고, 이후에 parallel stream 사용하여 DTO로 만드는 과정을 병렬처리
- 6000ms -> 40ms 성능 개선